### PR TITLE
fix(lobby/panel): Корректное распределение начала отсчета званий

### DIFF
--- a/src/main/kotlin/jp/assasans/protanki/server/client/User.kt
+++ b/src/main/kotlin/jp/assasans/protanki/server/client/User.kt
@@ -105,5 +105,5 @@ class User(
     }
 
   val currentRankScore: Int
-    get() = rank.score - score
+    get() = rank.scoreOrZero
 }


### PR DESCRIPTION
currentRankScore не должен быть равен 0